### PR TITLE
Added support for comments (same as for c++)

### DIFF
--- a/Comments (AngelScript).tmPreferences
+++ b/Comments (AngelScript).tmPreferences
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Comments</string>
+	<key>scope</key>
+	<string>source.angelscript</string>
+	<key>settings</key>
+	<dict>
+		<key>shellVariables</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START</string>
+				<key>value</key>
+				<string>// </string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START_2</string>
+				<key>value</key>
+				<string>/*</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_END_2</string>
+				<key>value</key>
+				<string>*/</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_DISABLE_INDENT_2</string>
+				<key>value</key>
+				<string>yes</string>
+			</dict>		
+		</array>
+	</dict>
+	<key>uuid</key>
+	<string>627182cf-5d61-4e82-88ad-ea7232f95e20</string>
+</dict>
+</plist>


### PR DESCRIPTION
I added a syntax file to add support for the keyboard comment shortcuts. The file uses the same rules as c++ (e.g. "//" and "/**/")
